### PR TITLE
chore 📦: Update repository URLs in pyproject.toml and setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ A command-line tool for matching video files with their corresponding subtitle f
 ### Option 1: Using pipx (Recommended)
 
 ```bash
-pipx install "https://github.com/beecave-homelab/subber.git"
+pipx install "git+https://github.com/beecave-homelab/subber.git"
 ```
 
 ### Option 2: Using virtualenv (For development)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,8 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/elvee/subber"
-Repository = "https://github.com/elvee/subber"
+Homepage = "https://github.com/beecave-homelab/subber"
+Repository = "https://github.com/beecave-homelab/subber"
 
 [project.scripts]
 subber = "subber.cli.main:main"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     description="A tool for matching video files with subtitle files",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/elvee/subber",
+    url="https://github.com/beecave-homelab/subber",
     packages=find_packages(),
     classifiers=[
         "Development Status :: 3 - Alpha",
@@ -34,6 +34,7 @@ setup(
         "questionary>=2.0.0",
         "rapidfuzz>=3.0.0",
         "tabulate>=0.9.0",
+        "better-ffmpeg-progress>=1.1.0",
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
This change updates the homepage and repository URLs in both `pyproject.toml` and `setup.py` to reflect the new project location at `beecave-homelab/subber`. This ensures that all references to the project are consistent with its current location, improving transparency and reliability for contributors and users. This should fix the pipx installation errors.